### PR TITLE
When sanitizing html, disable link creation when already under an anc…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 1.4.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- When sanitizing html, disable link creation when already under an anchor.
 
 
 1.4.0 (2020-06-17)

--- a/src/nti/contentfragments/html.py
+++ b/src/nti/contentfragments/html.py
@@ -176,7 +176,11 @@ class _SanitizerFilter(sanitizer.Filter):
         self._ignored_elements = frozenset(['script', 'style'])
         self._ignoring_stack = []
 
-        self._in_anchor = False
+        self._anchor_depth = 0
+
+    @property
+    def _in_anchor(self):
+        return self._anchor_depth > 0
 
     def __iter__(self):
         for token in super(_SanitizerFilter, self).__iter__():
@@ -237,10 +241,11 @@ class _SanitizerFilter(sanitizer.Filter):
 
         # Indicate whether we're in an anchor tag
         if token.get('name') == 'a':
+            # Trigger on start/end tags, not others (e.g. empty tags)
             if token_type == 'StartTag':
-                self._in_anchor = True
+                self._anchor_depth += 1
             elif token_type == 'EndTag':
-                self._in_anchor = False
+                self._anchor_depth -= 1
 
         result = super(_SanitizerFilter, self).sanitize_token(token)
         return result

--- a/src/nti/contentfragments/tests/test_html.py
+++ b/src/nti/contentfragments/tests/test_html.py
@@ -176,6 +176,12 @@ class TestHTTML(ContentfragmentsLayerTest):
             for attr_name in allowed_attrs:
                 self._test_allowed_attribute_provider(attr_name)
 
+    def test_existing_links(self):
+        # Ensure we properly handle html with existing anchors
+        html = '<html><body><p><a href="http://www.google.com">www.google.com</a></p></body></html>'
+        exp = '<html><body><p><a href="http://www.google.com">www.google.com</a></p></body></html>'
+        _check_sanitized(html, exp)
+
 
 @contextlib.contextmanager
 def _provide_utility(util):

--- a/src/nti/contentfragments/tests/test_html.py
+++ b/src/nti/contentfragments/tests/test_html.py
@@ -189,8 +189,9 @@ class TestHTTML(ContentfragmentsLayerTest):
 
     def test_link_creation(self):
         # Ensure we properly handle html with existing anchors
-        html = 'www.google.com'
-        exp = '<html><body><a href="http://www.google.com">www.google.com</a></body></html>'
+        html = '<p><a href="nextthought.com">NTI</a>www.google.com</p>'
+        exp = '<html><body><p><a href="nextthought.com">NTI</a>' \
+              '<a href="http://www.google.com">www.google.com</a></p></body></html>'
         _check_sanitized(html, exp)
 
 

--- a/src/nti/contentfragments/tests/test_html.py
+++ b/src/nti/contentfragments/tests/test_html.py
@@ -177,9 +177,20 @@ class TestHTTML(ContentfragmentsLayerTest):
                 self._test_allowed_attribute_provider(attr_name)
 
     def test_existing_links(self):
+        allowed_attribute_provider = self._allowed_attr_provider(["data-nti-entity-href"])
+
+        with _provide_utility(allowed_attribute_provider):
+            # Ensure we properly handle html with existing anchors
+            html = '<p><a data-nti-entity-href="http://www.google.com" ' \
+                   'href="http://www.google.com">www.google.com</a></p>'
+            exp = '<html><body><p><a data-nti-entity-href="http://www.google.com" ' \
+                  'href="http://www.google.com">www.google.com</a></p></body></html>'
+            _check_sanitized(html, exp)
+
+    def test_link_creation(self):
         # Ensure we properly handle html with existing anchors
-        html = '<html><body><p><a href="http://www.google.com">www.google.com</a></p></body></html>'
-        exp = '<html><body><p><a href="http://www.google.com">www.google.com</a></p></body></html>'
+        html = 'www.google.com'
+        exp = '<html><body><a href="http://www.google.com">www.google.com</a></body></html>'
         _check_sanitized(html, exp)
 
 

--- a/src/nti/contentfragments/tests/test_html.py
+++ b/src/nti/contentfragments/tests/test_html.py
@@ -188,10 +188,19 @@ class TestHTTML(ContentfragmentsLayerTest):
             _check_sanitized(html, exp)
 
     def test_link_creation(self):
-        # Ensure we properly handle html with existing anchors
+        # Ensure links are created for url-like text following anchors
         html = '<p><a href="nextthought.com">NTI</a>www.google.com</p>'
         exp = '<html><body><p><a href="nextthought.com">NTI</a>' \
               '<a href="http://www.google.com">www.google.com</a></p></body></html>'
+        _check_sanitized(html, exp)
+
+    def test_nested_anchors(self):
+        # Links should not be created for the url-like text and nesting
+        # will be split
+        html = '<p><a href="www.nextthought.com">www.nextthought.com' \
+               '<a href="www.google.com">www.google.com</a></a></p>'
+        exp = '<html><body><p><a href="www.nextthought.com">www.nextthought.com</a>' \
+              '<a href="www.google.com">www.google.com</a></p></body></html>'
         _check_sanitized(html, exp)
 
 


### PR DESCRIPTION
…hor.

We were running into this:
```html
<p><a data-nti-entity-type="LINK" data-nti-entity-mutability="MUTABLE" href="http://www.google.com" data-nti-entity-href="http://www.google.com" data-nti-entity-contiguous="false" data-nti-entity-autoLink="true" data-nti-entity-has-preview="preview">www.google.com</a></p>
```

getting turned into this:
```html
<html><body><p><a data-nti-entity-mutability="MUTABLE" data-nti-entity-type="LINK" href="http://www.google.com"></a><a href="http://www.google.com">www.google.com</a></p></body></html>
```
