### PR TITLE
Add support for reStructuredText content fragments.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,11 @@
  Changes
 =========
 
-1.5.1 (unreleased)
+1.6.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add support for reStructuredText content fragments and corresponding
+  fields.
 
 
 1.5.0 (2020-07-23)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def _read(fname):
     with codecs.open(fname, encoding='utf-8') as f:
         return f.read()
 
-version = '1.5.1.dev0'
+version = '1.6.0.dev0'
 
 setup(
     name='nti.contentfragments',

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         # https://github.com/pytries/datrie/issues/52
 
         "datrie >= 0.8.2 ; platform_python_implementation == 'CPython'",
+        'docutils',
     ],
     extras_require={
         'test': TESTS_REQUIRE,

--- a/src/nti/contentfragments/configure.zcml
+++ b/src/nti/contentfragments/configure.zcml
@@ -67,6 +67,10 @@
              for=".interfaces.IUnicode"
              provides=".interfaces.IHTMLContentFragment" />
 
+    <adapter factory=".interfaces.RstContentFragment"
+             for=".interfaces.IUnicode"
+             provides=".interfaces.IRstContentFragment" />
+
     <!--
     We can convert arbitrary strings to a unicode content fragment.
     This will either create a plain text or HTML fragment.

--- a/src/nti/contentfragments/configure.zcml
+++ b/src/nti/contentfragments/configure.zcml
@@ -67,7 +67,7 @@
              for=".interfaces.IUnicode"
              provides=".interfaces.IHTMLContentFragment" />
 
-    <adapter factory=".interfaces.RstContentFragment"
+    <adapter factory=".rst.check_user_rst"
              for=".interfaces.IUnicode"
              provides=".interfaces.IRstContentFragment" />
 

--- a/src/nti/contentfragments/interfaces.py
+++ b/src/nti/contentfragments/interfaces.py
@@ -588,7 +588,7 @@ class IRstContentFragmentField(ITextUnicodeContentFragmentField):
     A :class:`~zope.schema.Text` type that also requires the object implement
     an interface descending from :class:`.IRstContentFragment`.
 
-    .. versionadded:: 1.2.0
+    .. versionadded:: 1.6.0
     """
 
 

--- a/src/nti/contentfragments/interfaces.py
+++ b/src/nti/contentfragments/interfaces.py
@@ -236,6 +236,18 @@ class IHTMLContentFragment(IUnicodeContentFragment, IContentTypeTextHtml):
     """
 
 
+IContentTypeTextRst = getattr(mime_types, 'IContentTypeTextRst')
+class IRstContentFragment(IUnicodeContentFragment, IContentTypeTextRst):
+    """
+    Interface representing content in RST format.
+    """
+
+
+@interface.implementer(IRstContentFragment)
+class RstContentFragment(UnicodeContentFragment):
+    pass
+
+
 # NOTE The implementations of the add methods go directly to
 # unicode and not up the super() chain to avoid as many extra
 # copies as possible
@@ -569,6 +581,16 @@ class IPlainTextField(ITextUnicodeContentFragmentField):
 
     .. versionadded:: 1.2.0
     """
+
+
+class IRstContentFragmentField(ITextUnicodeContentFragmentField):
+    """
+    A :class:`~zope.schema.Text` type that also requires the object implement
+    an interface descending from :class:`.IRstContentFragment`.
+
+    .. versionadded:: 1.2.0
+    """
+
 
 class ITagField(IPlainTextLineField):
     """

--- a/src/nti/contentfragments/mime.types
+++ b/src/nti/contentfragments/mime.types
@@ -1,1 +1,2 @@
 application/json	jsonp
+text/x-rst	rst

--- a/src/nti/contentfragments/rst.py
+++ b/src/nti/contentfragments/rst.py
@@ -9,6 +9,10 @@ __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
 
+import sys
+
+import six
+
 from docutils.core import publish_parts
 from docutils.utils import SystemMessage
 
@@ -51,6 +55,6 @@ def check_user_rst(input):
             settings = SETTINGS.copy()
             publish_parts(input, settings_overrides=settings)
         except SystemMessage as e:
-            raise RstParseError(e.args[0])
+            six.reraise(RstParseError, RstParseError(*e.args), sys.exc_info()[2])
 
     return RstContentFragment(input)

--- a/src/nti/contentfragments/rst.py
+++ b/src/nti/contentfragments/rst.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Support for reStructuredText content fragments.
+"""
+
+from __future__ import print_function, absolute_import, division
+__docformat__ = "restructuredtext en"
+
+logger = __import__('logging').getLogger(__name__)
+
+from docutils.core import publish_parts
+from docutils.utils import SystemMessage
+
+from .interfaces import RstContentFragment
+
+
+SETTINGS = {
+    # Prevent local files from being included into the rendered output.
+    # This is a security concern because people can insert files
+    # that are part of the system, such as /etc/passwd.
+    "file_insertion_enabled": False,
+
+    # Halt rendering and throw an exception if there was any errors or
+    # warnings from docutils.
+    "halt_level": 3,
+
+    # Disable raw html as enabling it is a security risk, we do not want
+    # people to be able to include any old HTML in the final output.
+    "raw_enabled": False,
+
+    # Disable all system messages from being reported.
+    "report_level": 5,
+
+    # Use the short form of syntax highlighting so that the generated
+    # Pygments CSS can be used to style the output.
+    "syntax_highlight": "none",
+}
+
+
+class RstParseError(Exception):
+    """
+    An error has occurred parsing reStructuredText
+    """
+
+
+def check_user_rst(input):
+
+    if input:
+        try:
+            settings = SETTINGS.copy()
+            publish_parts(input, settings_overrides=settings)
+        except SystemMessage as e:
+            raise RstParseError(e.args[0])
+
+    return RstContentFragment(input)

--- a/src/nti/contentfragments/schema.py
+++ b/src/nti/contentfragments/schema.py
@@ -8,6 +8,10 @@ or :mod:`zope.schema` declarations.
 """
 
 from __future__ import print_function, absolute_import, division
+
+from nti.contentfragments.interfaces import IRstContentFragment
+from nti.contentfragments.interfaces import IRstContentFragmentField
+
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
@@ -20,6 +24,7 @@ import unicodedata
 from zope.interface import implementer
 
 from .interfaces import HTMLContentFragment as HTMLContentFragmentType
+from .interfaces import RstContentFragment as RstContentFragmentType
 from .interfaces import IHTMLContentFragment
 from .interfaces import LatexContentFragment
 from .interfaces import ILatexContentFragment
@@ -69,6 +74,7 @@ class _FromUnicodeMixin(object):
 
         # We're imported too early for ZCA to be configured and we can't automatically
         # adapt.
+        from IPython.terminal.debugger import set_trace; set_trace()
         if 'default' in kwargs and not self._iface.providedBy(kwargs['default']):
             kwargs['default'] = self._impl(kwargs['default'])
         if 'default' not in kwargs and 'defaultFactory' not in kwargs and not kwargs.get('min_length'):  # 0/None
@@ -194,6 +200,27 @@ class SanitizedHTMLContentFragment(HTMLContentFragment):
 
     _iface = ISanitizedHTMLContentFragment
     _impl = SanitizedHTMLContentFragmentType
+
+
+@implementer(IRstContentFragmentField)
+class RstContentFragment(TextUnicodeContentFragment):
+    """
+    A :class:`Text` type that also requires the object implement
+    an interface descending from :class:`.IRstContentFragment`.
+    Note that currently this does no validation of the content to
+    ensure it is valid reStructuredText.
+
+    Pass the keyword arguments for :class:`zope.schema.Text` to the constructor; the ``schema``
+    argument for :class:`~zope.schema.Object` is already handled.
+
+    .. note:: If you provide a ``default`` string that does not already provide :class:`.ISanitizedHTMLContentFragment`,
+        one will be created simply by copying; no validation or transformation will occur.
+
+    """
+
+    _iface = IRstContentFragment
+    _impl = RstContentFragmentType
+
 
 @implementer(IPlainTextField)
 class PlainText(TextUnicodeContentFragment):

--- a/src/nti/contentfragments/schema.py
+++ b/src/nti/contentfragments/schema.py
@@ -19,6 +19,8 @@ import unicodedata
 
 from zope.interface import implementer
 
+from zope.schema.interfaces import InvalidValue
+
 from .interfaces import HTMLContentFragment as HTMLContentFragmentType
 from .interfaces import IHTMLContentFragment
 from .interfaces import LatexContentFragment
@@ -42,10 +44,12 @@ from .interfaces import ISanitizedHTMLContentFragmentField
 from .interfaces import ITagField
 from .interfaces import IRstContentFragmentField
 
+from .rst import RstParseError
 
 from nti.schema.field import Object
 from nti.schema.field import ValidText as Text
 from nti.schema.field import ValidTextLine as TextLine
+
 
 class _FromUnicodeMixin(object):
 
@@ -218,6 +222,12 @@ class RstContentFragment(TextUnicodeContentFragment):
 
     _iface = IRstContentFragment
     _impl = RstContentFragmentType
+
+    def fromUnicode(self, value):
+        try:
+            return _FromUnicodeMixin.fromUnicode(self, value)
+        except RstParseError as e:
+            raise InvalidValue("Error parsing reStructuredText: %s" % (e.args[0],))
 
 
 @implementer(IPlainTextField)

--- a/src/nti/contentfragments/schema.py
+++ b/src/nti/contentfragments/schema.py
@@ -8,10 +8,6 @@ or :mod:`zope.schema` declarations.
 """
 
 from __future__ import print_function, absolute_import, division
-
-from nti.contentfragments.interfaces import IRstContentFragment
-from nti.contentfragments.interfaces import IRstContentFragmentField
-
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
@@ -24,7 +20,6 @@ import unicodedata
 from zope.interface import implementer
 
 from .interfaces import HTMLContentFragment as HTMLContentFragmentType
-from .interfaces import RstContentFragment as RstContentFragmentType
 from .interfaces import IHTMLContentFragment
 from .interfaces import LatexContentFragment
 from .interfaces import ILatexContentFragment
@@ -34,6 +29,8 @@ from .interfaces import PlainTextContentFragment
 from .interfaces import IPlainTextContentFragment
 from .interfaces import SanitizedHTMLContentFragment as SanitizedHTMLContentFragmentType
 from .interfaces import ISanitizedHTMLContentFragment
+from .interfaces import RstContentFragment as RstContentFragmentType
+from .interfaces import IRstContentFragment
 
 from .interfaces import ITextUnicodeContentFragmentField
 from .interfaces import ITextLineUnicodeContentFragmentField
@@ -43,6 +40,8 @@ from .interfaces import IPlainTextField
 from .interfaces import IHTMLContentFragmentField
 from .interfaces import ISanitizedHTMLContentFragmentField
 from .interfaces import ITagField
+from .interfaces import IRstContentFragmentField
+
 
 from nti.schema.field import Object
 from nti.schema.field import ValidText as Text
@@ -212,7 +211,7 @@ class RstContentFragment(TextUnicodeContentFragment):
     Pass the keyword arguments for :class:`zope.schema.Text` to the constructor; the ``schema``
     argument for :class:`~zope.schema.Object` is already handled.
 
-    .. note:: If you provide a ``default`` string that does not already provide :class:`.ISanitizedHTMLContentFragment`,
+    .. note:: If you provide a ``default`` string that does not already provide :class:`.IRstContentFragment`,
         one will be created simply by copying; no validation or transformation will occur.
 
     """

--- a/src/nti/contentfragments/schema.py
+++ b/src/nti/contentfragments/schema.py
@@ -15,7 +15,10 @@ logger = __import__('logging').getLogger(__name__)
 # pylint: disable=too-many-ancestors
 # pylint:disable=useless-object-inheritance
 
+import sys
 import unicodedata
+
+import six
 
 from zope.interface import implementer
 
@@ -227,8 +230,9 @@ class RstContentFragment(TextUnicodeContentFragment):
         try:
             return _FromUnicodeMixin.fromUnicode(self, value)
         except RstParseError as e:
-            raise InvalidValue("Error parsing reStructuredText: %s" % (e.args[0],))
-
+            ex = InvalidValue("Error parsing reStructuredText: %s" % (e,))
+            ex = ex.with_field_and_value(self, value)
+            six.reraise(InvalidValue, ex, sys.exc_info()[2])
 
 @implementer(IPlainTextField)
 class PlainText(TextUnicodeContentFragment):

--- a/src/nti/contentfragments/schema.py
+++ b/src/nti/contentfragments/schema.py
@@ -74,7 +74,6 @@ class _FromUnicodeMixin(object):
 
         # We're imported too early for ZCA to be configured and we can't automatically
         # adapt.
-        from IPython.terminal.debugger import set_trace; set_trace()
         if 'default' in kwargs and not self._iface.providedBy(kwargs['default']):
             kwargs['default'] = self._impl(kwargs['default'])
         if 'default' not in kwargs and 'defaultFactory' not in kwargs and not kwargs.get('min_length'):  # 0/None

--- a/src/nti/contentfragments/tests/test_interfaces.py
+++ b/src/nti/contentfragments/tests/test_interfaces.py
@@ -30,14 +30,12 @@ from zope import interface
 
 from zope.schema.interfaces import ConstraintNotSatisfied
 
-from . import ContentfragmentsLayerTest
-
 from ..interfaces import HTMLContentFragment
 from ..interfaces import UnicodeContentFragment
 from ..interfaces import PlainTextContentFragment
 from ..interfaces import IPlainTextContentFragment
 from ..interfaces import SanitizedHTMLContentFragment
-from ..interfaces import IUnicodeContentFragment
+from ..interfaces import RstContentFragment
 
 
 try:
@@ -81,6 +79,8 @@ class TestMisc(unittest.TestCase):
     def test_mime_types(self):
         assert_that(mimetypes.guess_type('foo.jsonp'),
                     is_(('application/json', None)))
+        assert_that(mimetypes.guess_type('foo.rst'),
+                    is_(('text/x-rst', None)))
 
     def test_cant_get_dict_weakref_of_frag(self):
         frag = HTMLContentFragment()
@@ -158,7 +158,8 @@ class TestMisc(unittest.TestCase):
 
     def test_dont_lose_type_on_common_ops(self):
 
-        for t in SanitizedHTMLContentFragment, HTMLContentFragment, PlainTextContentFragment:
+        for t in SanitizedHTMLContentFragment, HTMLContentFragment, \
+                 PlainTextContentFragment, RstContentFragment:
             s1 = t(u'safe')
 
             assert_that(s1.translate({ord('s'): u't'}), is_(t))

--- a/src/nti/contentfragments/tests/test_rst.py
+++ b/src/nti/contentfragments/tests/test_rst.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+__docformat__ = "restructuredtext en"
+
+from hamcrest import assert_that
+from hamcrest import calling
+from hamcrest import raises
+
+from nti.contentfragments.rst import check_user_rst
+from nti.contentfragments.rst import RstParseError
+
+from nti.contentfragments.tests import ContentfragmentsLayerTest
+
+
+class TestRST(ContentfragmentsLayerTest):
+
+    def test_check_rst(self):
+        content = "=====\nTitle\n=====\n\n.. sidebar:: sidebar title\n\n   Some more content"
+        check_user_rst(content)
+
+    def test_check_rst_failure(self):
+        content = "=====\nTitle\n=====\n\n.. sidebar:: sidebar title\n\nSome more content"
+        assert_that(calling(check_user_rst).with_args(content),
+                    raises(RstParseError, "Content block expected"))

--- a/src/nti/contentfragments/tests/test_schema.py
+++ b/src/nti/contentfragments/tests/test_schema.py
@@ -9,11 +9,15 @@ from __future__ import print_function
 
 
 from hamcrest import assert_that
+from hamcrest import calling
 from hamcrest import has_key
 from hamcrest import has_entries
 from hamcrest import is_
+from hamcrest import raises
 
 from zope.dottedname import resolve as dottedname
+
+from nti.schema.interfaces import InvalidValue
 
 from nti.testing.matchers import validly_provides
 from nti.testing.matchers import is_false
@@ -52,7 +56,14 @@ TestTextLineUnicodeContentFragment = _make_test_class('TextLineUnicodeContentFra
 TestLatexFragmentTextLine = _make_test_class('LatexFragmentTextLine')
 TestPlainTextLine = _make_test_class('PlainTextLine')
 TestHTMLContentFragment = _make_test_class('HTMLContentFragment')
-TestRstContentFragment = _make_test_class('RstContentFragment')
+
+
+class TestRstContentFragment(_make_test_class('RstContentFragment')):
+
+    def test_invalid_rst(self):
+        fragment = self._makeOne()
+        assert_that(calling(fragment.fromUnicode).with_args(u".. invalid::"),
+                    raises(InvalidValue, u"Unknown directive"))
 
 
 class TestSanitizedHTMLContentFragment(_make_test_class('SanitizedHTMLContentFragment')):

--- a/src/nti/contentfragments/tests/test_schema.py
+++ b/src/nti/contentfragments/tests/test_schema.py
@@ -52,6 +52,7 @@ TestTextLineUnicodeContentFragment = _make_test_class('TextLineUnicodeContentFra
 TestLatexFragmentTextLine = _make_test_class('LatexFragmentTextLine')
 TestPlainTextLine = _make_test_class('PlainTextLine')
 TestHTMLContentFragment = _make_test_class('HTMLContentFragment')
+TestRstContentFragment = _make_test_class('RstContentFragment')
 
 
 class TestSanitizedHTMLContentFragment(_make_test_class('SanitizedHTMLContentFragment')):

--- a/src/nti/contentfragments/types.csv
+++ b/src/nti/contentfragments/types.csv
@@ -1,3 +1,4 @@
 name, title, extensions, mime_types, icon_name, encoded
 IContentTypeTextLatex, LaTeX, .tex .latex, text/x-latex application/x-latex, , yes
 IContentTypeApplicationJsonp, JSONP, .jsonp, application/json, , yes
+IContentTypeTextRst, reStructuredText, .rst, text/x-rst, , yes


### PR DESCRIPTION
Provide a RST content-based type and field for use with survey authoring, specifically for [NTI-9582](https://nextthought.atlassian.net/browse/NTI-9582).  We don't currently do any processing on it, but this should provide some flexibility to do so later, if desired.