### PR TITLE
Provide conversion from rST to plain text.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 1.6.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Allow conversion of reStructuredText fragments to plain text.
 
 
 1.6.1 (2020-09-14)

--- a/src/nti/contentfragments/configure.zcml
+++ b/src/nti/contentfragments/configure.zcml
@@ -141,6 +141,18 @@
     <adapter factory=".interfaces._plain_text_to_plain_text"
              name="text" />
 
+    <!--
+        Provide for converting rST to plaintext.
+    -->
+    <adapter factory=".rst.rst_to_plaintext"
+             for=".interfaces.IRstContentFragment"
+             provides=".interfaces.IPlainTextContentFragment" />
+
+    <adapter factory=".rst.rst_to_plaintext"
+             name="text"
+             for=".interfaces.IRstContentFragment"
+             provides=".interfaces.IPlainTextContentFragment" />
+
     <!-- Censoring -->
     <!-- Defaults -->
     <utility factory=".censor._word_plus_trivial_profanity_scanner" />

--- a/src/nti/contentfragments/rst.py
+++ b/src/nti/contentfragments/rst.py
@@ -13,9 +13,12 @@ import sys
 
 import six
 
+from docutils.core import publish_doctree
 from docutils.core import publish_parts
+
 from docutils.utils import SystemMessage
 
+from .interfaces import PlainTextContentFragment
 from .interfaces import RstContentFragment
 
 
@@ -48,13 +51,25 @@ class RstParseError(Exception):
     """
 
 
+def _publish_doctree(input):
+    try:
+        settings = SETTINGS.copy()
+        return publish_doctree(input, settings_overrides=settings)
+    except SystemMessage as e:
+        six.reraise(RstParseError, RstParseError(*e.args), sys.exc_info()[2])
+
+
 def check_user_rst(input):
 
     if input:
-        try:
-            settings = SETTINGS.copy()
-            publish_parts(input, settings_overrides=settings)
-        except SystemMessage as e:
-            six.reraise(RstParseError, RstParseError(*e.args), sys.exc_info()[2])
+        _publish_doctree(input)
 
     return RstContentFragment(input)
+
+
+def rst_to_plaintext(input):
+
+    if input:
+        input = _publish_doctree(input).astext()
+
+    return PlainTextContentFragment(input)

--- a/src/nti/contentfragments/tests/test_rst.py
+++ b/src/nti/contentfragments/tests/test_rst.py
@@ -7,11 +7,17 @@ __docformat__ = "restructuredtext en"
 from hamcrest import assert_that
 from hamcrest import calling
 from hamcrest import raises
+from hamcrest import is_
+
+from nti.contentfragments.interfaces import IPlainTextContentFragment
+from nti.contentfragments.interfaces import IRstContentFragment
 
 from nti.contentfragments.rst import check_user_rst
 from nti.contentfragments.rst import RstParseError
 
 from nti.contentfragments.tests import ContentfragmentsLayerTest
+
+from nti.testing.matchers import verifiably_provides
 
 
 class TestRST(ContentfragmentsLayerTest):
@@ -24,3 +30,13 @@ class TestRST(ContentfragmentsLayerTest):
         content = "=====\nTitle\n=====\n\n.. sidebar:: sidebar title\n\nSome more content"
         assert_that(calling(check_user_rst).with_args(content),
                     raises(RstParseError, "Content block expected"))
+
+    def test_plaintext(self):
+        content = u"== ==\nH1 H2\n-- --\nc1 c2\n== ==\n\n"\
+                  u".. sidebar:: sidebar title\n\n   Some more content"
+        rst_content = IRstContentFragment(content)
+        assert_that(rst_content, verifiably_provides(IRstContentFragment))
+
+        plaintext = IPlainTextContentFragment(rst_content)
+        assert_that(plaintext, is_("\n\n\n\nH1\n\nH2\n\nc1\n\nc2\n\nsidebar title\n\nSome more content"))
+


### PR DESCRIPTION
The conversion here is pretty simplistic at the moment and doesn't do much in attempt to make it presentable.  Sadly docutils seems to provide no text translator.  Sphinx provides one, but we'd need to add that as a dependency and it doesn't seem built to our needs.  We could provide a full translator to help with that, similar to https://pypi.org/project/rst2txt/, it would just take a bit more time (also, not sure it will make much of a difference for the searching we currently need this for).  But let me know if we feel like that's something that we should invest time on.