### PR TITLE
Use html2text for plain text conversion

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -43,8 +43,10 @@ disable=wrong-import-position,
     cyclic-import,
     too-many-arguments,
     redefined-builtin,
-	useless-suppression,
-	mixed-indentation
+    useless-suppression,
+    mixed-indentation,
+    useless-object-inheritance
+
 #	undefined-all-variable
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,9 @@
 
 - Add support for Python 3.9.
 - Move to Github Actions from Travis CI.
-
+- The algorithm for converting HTML to plain text has been changed and
+  produces higher quality output. For example, links are preserved in
+  a human-readable fashion. See `issue 39 <https://github.com/NextThought/nti.contentfragments/issues/39>`_.
 
 1.7.0 (2020-10-07)
 ==================
@@ -19,7 +21,7 @@
 ==================
 
 - Ensure disallowed tags nested within anchors do not raise.
-  See `issue 34 <https://github.com/NextThought/nti.contentfragments/issues/34>`.
+  See `issue 34 <https://github.com/NextThought/nti.contentfragments/issues/34>`_.
 
 
 1.6.0 (2020-09-02)

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,10 @@ setup(
 
         "datrie >= 0.8.2 ; platform_python_implementation == 'CPython'",
         'docutils',
+
+        # For HTML to plain text (markdown) conversion.
+        # Python 2 support was dropped after 2019.8.11
+        'html2text >= 2019.8.11',
     ],
     extras_require={
         'test': TESTS_REQUIRE,

--- a/src/nti/contentfragments/configure.zcml
+++ b/src/nti/contentfragments/configure.zcml
@@ -83,6 +83,10 @@
              for=".interfaces.IUnicode"
              provides=".interfaces.IUnicodeContentFragment" />
 
+    <adapter factory=".html.sanitize_user_html"
+             for=".interfaces.IBytes"
+             provides=".interfaces.IUnicodeContentFragment" />
+
     <!-- This is something of a lie. It might sanitize to plain text -->
     <adapter factory=".html.sanitize_user_html"
              for=".interfaces.IHTMLContentFragment"
@@ -113,6 +117,9 @@
     <adapter factory=".html._sanitize_user_html_to_text"
              for=".interfaces.IUnicode"
              name="text"
+             provides=".interfaces.IPlainTextContentFragment" />
+    <adapter factory=".html._sanitize_user_html_to_text"
+             for=".interfaces.IBytes"
              provides=".interfaces.IPlainTextContentFragment" />
 
     <!--

--- a/src/nti/contentfragments/tests/contenttypes-notes-sanitized.txt
+++ b/src/nti/contentfragments/tests/contenttypes-notes-sanitized.txt
@@ -1,8 +1,5 @@
 <html><body><span style="color: rgb(0, 0, 0);">I like practicing the problem of the week from </span><u style="color: rgb(51, 102, 255);">MATHCOUNTS.</u> Mr. Madden, can you help me with some this semester?</body></html>
 <html><body><span style="color: rgb(0, 0, 0);">Hi, all.  I've found the following </span><font color="#0000ff"><u>video series </u></font>to be very helpful as you learn algebra.  Let me know if questions or if you find others.</body></html>
-Here is something that another friend told me about: themathpage_com/alg/algebra.htm
 <html><body><p style="text-align: left;"><span style="font-family: 'Helvetica'; font-size: 12pt; color: blue;">I like these Khan vid's khanacademy_org</span></p></body></html>
-Sure, Chris.  Feel free to chat when I'm online or submit a Quick Question for the community.
 <html><body><p style="text-align: left;"><span style="font-family: 'Helvetica'; font-size: 12pt; color: blue;">Hello, Whitney.  Could you pls answer this question:  asf asdf asdf asdf asdf asdf ?</span></p></body></html>
-Hi, Ken.  Here is the answer.  Check this website www_xyz_com
 <html><body><p style="text-decoration: underline;">Is it underlined?</p></body></html>

--- a/src/nti/contentfragments/tests/contenttypes-notes-tosanitize.plist
+++ b/src/nti/contentfragments/tests/contenttypes-notes-tosanitize.plist
@@ -4,11 +4,8 @@
 	<array>
 			<string>&lt;span style="color: rgb(0, 0, 0); "&gt;I like practicing the problem of the week from &lt;/span&gt;&lt;u style="color: rgb(51, 102, 255); "&gt;MATHCOUNTS.&lt;/u&gt;&amp;nbsp;Mr. Madden, can you help me with some this semester?</string>
 			<string>&lt;span style="color: rgb(0, 0, 0); "&gt;Hi, all. &amp;nbsp;I've found the following &lt;/span&gt;&lt;font color="#0000ff"&gt;&lt;u&gt;video series &lt;/u&gt;&lt;/font&gt;to be very helpful as you learn algebra. &amp;nbsp;Let me know if questions or if you find others.</string>
-			<string>Here is something that another friend told me about: themathpage_com/alg/algebra.htm&amp;nbsp;&lt;br&gt;&lt;br&gt;</string>
 			<string>&lt;html&gt;&lt;body&gt;&lt;p style=" text-align: left;" &gt;&lt;span style="font-family: 'Helvetica';  font-size: 12pt; color: blue;"&gt;I like these Khan vid&amp;#39;s khanacademy_org&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-			<string>Sure, Chris. &amp;nbsp;Feel free to chat when I'm online or submit a Quick Question for the community.</string>
 			<string>&lt;html&gt;&lt;body&gt;&lt;p style=" text-align: left;" &gt;&lt;span style="font-family: 'Helvetica';  font-size: 12pt; color: blue;"&gt;Hello, Whitney.  Could you pls answer this question:  asf asdf asdf asdf asdf asdf ?&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-			<string>Hi, Ken. &amp;nbsp;Here is the answer. &amp;nbsp;Check this website www_xyz_com</string>
 			<string>&lt;html&gt;&lt;body&gt;&lt;p style=" text-decoration: underline;"&gt;Is it underlined?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
 	</array>
 </plist>

--- a/src/nti/contentfragments/tests/test_html.py
+++ b/src/nti/contentfragments/tests/test_html.py
@@ -4,9 +4,9 @@
 from __future__ import print_function, absolute_import
 __docformat__ = "restructuredtext en"
 
-# pylint:disable=line-too-long
+# pylint:disable=line-too-long,too-many-public-methods
 
-
+import os
 import contextlib
 
 from hamcrest import is_
@@ -20,7 +20,7 @@ from nti.contentfragments.interfaces import IAllowedAttributeProvider
 
 from nti.testing.matchers import verifiably_provides
 
-import os
+
 try:
     from plistlib import load as load_plist
 except ImportError:
@@ -31,35 +31,93 @@ from nti.contentfragments import interfaces as frg_interfaces
 from nti.contentfragments.tests import ContentfragmentsLayerTest
 from nti.contentfragments import html as frag_html
 
-def _check_sanitized(inp, expect, expect_iface=frg_interfaces.IUnicodeContentFragment):
-    was = frg_interfaces.IUnicodeContentFragment(inp)
-    __traceback_info__ = inp, type(inp), was, type(was)
-    assert_that(was, is_(expect.strip()))
-    assert_that(was, verifiably_provides(expect_iface))
-    return was
 
-class TestHTTML(ContentfragmentsLayerTest):
+class _StringConversionMixin(object):
 
-    def test_sanitize_html(self):
+    # Converting to this interface produces the most suitable
+    # derived interfaces
+    CONV_IFACE = frg_interfaces.IUnicodeContentFragment
+
+    # This should be set to the most derived interface possible;
+    # tests should be structured to group input types that produce
+    # this interface.
+    EXP_IFACE = None
+
+    def _check_sanitized(self, inp, expect):
+        # Given exactly a raw string, not a content fragment.
+        assert type(inp) in (bytes, type(u'')) # pylint:disable=unidiomatic-typecheck
+        was = self.CONV_IFACE(inp)
+        __traceback_info__ = inp, type(inp), was, type(was)
+        assert_that(was, is_(expect.strip()))
+        assert_that(was, verifiably_provides(self.EXP_IFACE))
+        return was
+
+
+class TestStringInputToPlainTextOutput(_StringConversionMixin, ContentfragmentsLayerTest):
+
+    EXP_IFACE = frg_interfaces.IPlainTextContentFragment
+
+    def test_sanitize_removes_empty(self):
+        # If everything is removed, resulting in an empty string, it's just plain text.
+        html = '<html><body><span></span></body></html>'
+        exp = u''
+        self._check_sanitized(html, exp)
+
+        html = '<div>'
+        self._check_sanitized(html, u'')
+
+    def test_sanitize_remove_inner_elems_empty(self):
+        # As for `test_sanitize_removes_empty`, but here we have content hiding
+        # inside forbidden elements.
+        html = '<html><body><script><div /><span>Hi</span></script><style><span>hi</span></style></body></html>'
+        exp = u''
+        self._check_sanitized(html, exp)
+
+    def test_sanitize_remove_tags_leave_content(self):
+        # If all tags are removed, its just plain text
+        html = u'<html><body><div style=" text-align: left;">The text</div></body></html>'
+        exp = u'The text'
+        self._check_sanitized(html, exp)
+
+    def test_entity_trailing_break_removal(self):
+        html = u'Here is something that another friend told me about: themathpage_com/alg/algebra.htm&nbsp;<br><br>'
+        expt = u'Here is something that another friend told me about: themathpage_com/alg/algebra.htm'
+        self._check_sanitized(html, expt)
+
+        html = u"Sure, Chris. &nbsp;Feel free to chat when I'm online or submit a Quick Question for the community."
+        expt = u"Sure, Chris.  Feel free to chat when I'm online or submit a Quick Question for the community."
+        self._check_sanitized(html, expt)
+
+        html = u'Hi, Ken. &nbsp;Here is the answer. &nbsp;Check this website www_xyz_com'
+        expt = u'Hi, Ken.  Here is the answer.  Check this website www_xyz_com\n'
+        self._check_sanitized(html, expt)
+
+
+class TestStringToSanitizedHTML(_StringConversionMixin, ContentfragmentsLayerTest):
+
+    EXP_IFACE = frg_interfaces.ISanitizedHTMLContentFragment
+
+    def test_sanitize_html_examples(self):
         with open(os.path.join(os.path.dirname(__file__), 'contenttypes-notes-tosanitize.plist'), 'rb') as f:
-            strings = load_plist(f)
+            strings = load_plist(f) # pylint:disable=deprecated-method
         with open(os.path.join(os.path.dirname(__file__), 'contenttypes-notes-sanitized.txt')) as f:
             sanitized = f.readlines()
 
+        assert len(strings) == len(sanitized)
         for s in zip(strings, sanitized):
-            _check_sanitized(s[0], s[1])
+            self._check_sanitized(*s)
 
     def test_sanitize_data_uri(self):
-        _ = _check_sanitized("<audio src='data:foobar' controls />",
-                             u'<html><body><audio controls=""></audio></body></html>')
+        self._check_sanitized("<audio src='data:foobar' controls />",
+                              u'<html><body><audio controls=""></audio></body></html>')
 
-        _ = _check_sanitized("<audio data-id='ichigo' />",
-                             u'<html><body><audio data-id="ichigo"></audio></body></html>')
+        self._check_sanitized("<audio data-id='ichigo' />",
+                              u'<html><body><audio data-id="ichigo"></audio></body></html>')
 
     def test_normalize_html_text_to_par(self):
         html = u'<html><body><p style=" text-align: left;"><span style="font-family: \'Helvetica\';  font-size: 12pt; color: black;">The pad replies to my note.</span></p>The server edits it.</body></html>'
         exp = u'<html><body><p style="text-align: left;"><span>The pad replies to my note.</span></p><p style="text-align: left;">The server edits it.</p></body></html>'
-        sanitized = _check_sanitized(html, exp, frg_interfaces.ISanitizedHTMLContentFragment)
+        sanitized = self._check_sanitized(html, exp)
 
         plain_text = frg_interfaces.IPlainTextContentFragment(sanitized)
         assert_that(plain_text, verifiably_provides(frg_interfaces.IPlainTextContentFragment))
@@ -68,20 +126,20 @@ class TestHTTML(ContentfragmentsLayerTest):
     def test_normalize_simple_style_color(self):
         html = u'<html><body><p><span style="color: black;">4</span></p></body></html>'
         exp = html
-        sanitized = _check_sanitized(html, exp, frg_interfaces.ISanitizedHTMLContentFragment)
+        sanitized = self._check_sanitized(html, exp)
         assert_that(sanitized, is_(exp))
 
     def test_normalize_simple_style_font(self):
         html = u'<html><body><p><span style="font-family: sans-serif;">4</span></p></body></html>'
         exp = html
-        sanitized = _check_sanitized(html, exp, frg_interfaces.ISanitizedHTMLContentFragment)
+        sanitized = self._check_sanitized(html, exp)
 
         assert_that(sanitized, is_(exp))
 
     def test_normalize_style_with_quoted_dash(self):
         html = u'<html><body><p style="text-align: left;"><span style="font-family: \'Helvetica-Bold\'; font-size: 12pt; font-weight: bold; color: black;">4</span></p></body></html>'
         exp = html
-        sanitized = _check_sanitized(html, exp, frg_interfaces.ISanitizedHTMLContentFragment)
+        sanitized = self._check_sanitized(html, exp)
         assert_that(sanitized, is_(exp))
 
     def test_html_to_text(self):
@@ -91,26 +149,22 @@ class TestHTTML(ContentfragmentsLayerTest):
         assert_that(plain_text, is_("The pad replies to my note.The server edits it."))
 
     def test_rejected_tags(self):
-        html = u'<html><body><div style=" text-align: left;">The text</div></body></html>'
-        exp = 'The text'
-        _check_sanitized(html, exp, frg_interfaces.IPlainTextContentFragment)
-
         html = u'<html><body><style>* { font: "Helvetica";}</style><p style=" text-align: left;">The text</div></body></html>'
         exp = u'<html><body><p style="text-align: left;">The text</p></body></html>'
-        _check_sanitized(html, exp, frg_interfaces.ISanitizedHTMLContentFragment)
+        self._check_sanitized(html, exp)
 
         html = u'<html><body><script><p>should be ignored</p> Other stuff.</script><p style=" text-align: left;">The text</div></body></html>'
         exp = u'<html><body><p style="text-align: left;">The text</p></body></html>'
-        _check_sanitized(html, exp, frg_interfaces.ISanitizedHTMLContentFragment)
+        self._check_sanitized(html, exp)
 
-        html = u'foo<div><br></div><div>http://google.com</div><div><br></div><div>bar</div><div><br></div><div>http://yahoo.com</div>'''
+        html = u'foo<div><br></div><div>http://google.com</div><div><br></div><div>bar</div><div><br></div><div>http://yahoo.com</div>'
         exp = u'<html><body>foo<br /><a href="http://google.com">http://google.com</a><br />bar<br /><a href="http://yahoo.com">http://yahoo.com</a></body></html>'
-        _check_sanitized(html, exp, frg_interfaces.ISanitizedHTMLContentFragment)
+        self._check_sanitized(html, exp)
 
     def test_pre_allowed(self):
         html = u'<html><body><pre>The text</pre></body></html>'
         exp = html
-        _check_sanitized(html, exp)
+        self._check_sanitized(html, exp)
 
     def test_blog_html_to_text(self):
         exp = u'<html><body>Independence<br />America<br />Expecting<br />Spaces</body></html>'
@@ -118,10 +172,23 @@ class TestHTTML(ContentfragmentsLayerTest):
         assert_that(plain_text, verifiably_provides(frg_interfaces.IPlainTextContentFragment))
         assert_that(plain_text, is_("Independence\nAmerica\nExpecting\nSpaces"))
 
-    def test_sanitize_user_html_chat(self):
-        exp = u'<html><a href=\'http://tag:nextthought.com,2011-10:julie.zhu-OID-0x148a37:55736572735f315f54657374:hjJe3dfZMVb,"body":["5:::{\\"args\\\'>foo</html>'
-        plain_text = frg_interfaces.IPlainTextContentFragment(exp)
+    def test_links_preserved_plain_string_html_to_text(self):
+        html = u'<html><body><div>For help, <a href="email:support@nextthought.com">email us</a></div></html>'
+        plain_text = frg_interfaces.IPlainTextContentFragment(html)
         assert_that(plain_text, verifiably_provides(frg_interfaces.IPlainTextContentFragment))
+        # The lxml implementation loses the link entirely.
+        # expected = """For help, [email us](email:support@nextthought.com)"""
+        expected = """For help, email us"""
+        assert_that(plain_text, is_(expected))
+
+    def test_sanitize_user_html_chat(self):
+        html = u'<html><a href=\'http://tag:nextthought.com,2011-10:julie.zhu-OID-0x148a37:55736572735f315f54657374:hjJe3dfZMVb,"body":["5:::{\\"args\\\'>foo</html>'
+        plain_text = frg_interfaces.IPlainTextContentFragment(html)
+        assert_that(plain_text, verifiably_provides(frg_interfaces.IPlainTextContentFragment))
+        # Was just "foo" in the lxml based implementation
+        expected = "foo"
+        #expected = """[foo"""
+        assert_that(plain_text, is_(expected))
 
         # idempotent
         assert_that(frag_html._sanitize_user_html_to_text(plain_text),
@@ -132,25 +199,15 @@ class TestHTTML(ContentfragmentsLayerTest):
     def test_sanitize_img(self):
         html = '<html><body><img style="color: blue; text-align: left; max-width: 10px" href="foo"></body></html>'
         exp = '<html><body><img href="foo" style="color: blue; text-align: left; max-width: 100%;" /></body></html>'
-        _check_sanitized(html, exp)
+        self._check_sanitized(html, exp)
 
         html = '<html><body><img style="" href="foo"></body></html>'
         exp = '<html><body><img href="foo" style="max-width: 100%;" /></body></html>'
-        _check_sanitized(html, exp)
+        self._check_sanitized(html, exp)
 
         html = '<html><body><img max-width="1%" href="foo"></body></html>'
         exp = '<html><body><img href="foo" style="max-width: 100%;" /></body></html>'
-        _check_sanitized(html, exp)
-
-    def test_sanitize_empty_span(self):
-        html = '<html><body><span></span></body></html>'
-        exp = ''
-        _check_sanitized(html, exp)
-
-    def test_sanitize_remove_inner_elems(self):
-        html = '<html><body><script><div /><span>Hi</span></script><style><span>hi</span></style></body></html>'
-        exp = ''
-        _check_sanitized(html, exp)
+        self._check_sanitized(html, exp)
 
     def _allowed_attr_provider(self, attrs_to_allow):
         class TestAllowedAttrProvider(object):
@@ -160,20 +217,20 @@ class TestHTTML(ContentfragmentsLayerTest):
         interface.alsoProvides(allowed_attribute_provider, (IAllowedAttributeProvider,))
         return allowed_attribute_provider
 
-    def _test_allowed_attribute_provider(self, attr_name, included=True):
+    def _check_allowed_attribute_provider(self, attr_name, included=True):
         html = '<html><body><a %s="my_value">Bobby Hagen</a></body></html>' % attr_name
         exp = html if included else '<html><body><a>Bobby Hagen</a></body></html>'
-        _check_sanitized(html, exp)
+        self._check_sanitized(html, exp)
 
     def test_allowed_attribute_provider(self):
-        self._test_allowed_attribute_provider("abc", included=False)
+        self._check_allowed_attribute_provider("abc", included=False)
 
         allowed_attrs = ["abc", "xyz"]
         allowed_attribute_provider = self._allowed_attr_provider(allowed_attrs)
 
         with _provide_utility(allowed_attribute_provider):
             for attr_name in allowed_attrs:
-                self._test_allowed_attribute_provider(attr_name)
+                self._check_allowed_attribute_provider(attr_name)
 
     def test_existing_links(self):
         allowed_attribute_provider = self._allowed_attr_provider(["data-nti-entity-href"])
@@ -184,14 +241,14 @@ class TestHTTML(ContentfragmentsLayerTest):
                    'href="http://www.google.com">www.google.com</a></p>'
             exp = '<html><body><p><a data-nti-entity-href="http://www.google.com" ' \
                   'href="http://www.google.com">www.google.com</a></p></body></html>'
-            _check_sanitized(html, exp)
+            self._check_sanitized(html, exp)
 
     def test_link_creation(self):
         # Ensure links are created for url-like text following anchors
         html = '<p><a href="nextthought.com">NTI</a>www.google.com</p>'
         exp = '<html><body><p><a href="nextthought.com">NTI</a>' \
               '<a href="http://www.google.com">www.google.com</a></p></body></html>'
-        _check_sanitized(html, exp)
+        self._check_sanitized(html, exp)
 
     def test_nested_anchors(self):
         # Links should not be created for the url-like text and nesting
@@ -200,15 +257,11 @@ class TestHTTML(ContentfragmentsLayerTest):
                '<a href="www.google.com">www.google.com</a></a></p>'
         exp = '<html><body><p><a href="www.nextthought.com">www.nextthought.com</a>' \
               '<a href="www.google.com">www.google.com</a></p></body></html>'
-        _check_sanitized(html, exp)
-
-    def test_disallowed(self):
-        html = '<div>'
-        _check_sanitized(html, u'')
+        self._check_sanitized(html, exp)
 
     def test_disallowed_within_anchor(self):
         html = '<a href="www.nextthought.com"><div>test</div></a>'
-        _check_sanitized(html, u'<html><body><a href="www.nextthought.com">test</a></body></html>')
+        self._check_sanitized(html, u'<html><body><a href="www.nextthought.com">test</a></body></html>')
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
In all scenarios in which we do that. I couldn't find a downside. This happens both when converting from a random string or HTML-based content fragment to a plain text fragment, or when converting random strings to unicode content fragments (which generates the most derived possible fragment kind, preferring plain text). 

Converting random strings to unicode content fragments first goes through our full sanitization routine, and only if that is deemed clean (text-only) do we produce plain text. That's still the same, but now html2text has a chance to handle the formatting. I don't see any security implications of that.

The first commit just reorganizes the tests a bit to make it more clear what conversion they're testing, and the next commit does the actual work. Basically no existing tests had to change, except one which was dealing with malformed and thus unparseable HTML.

cf https://github.com/NextThought/nti.dataserver/pull/411