### PR TITLE
This fixes an issue in our html sanitization when no IHyperlinkFormatter is registered

### DIFF
--- a/src/nti/contentfragments/html.py
+++ b/src/nti/contentfragments/html.py
@@ -198,9 +198,10 @@ class _SanitizerFilter(sanitizer.Filter):
     def _find_links_in_text(self, token):
         if self.link_finder is None:
             yield token
+            return
             
         text = token['data']
-        text_and_links = self.link_finder.find_links(text) if self.link_finder else ()
+        text_and_links = self.link_finder.find_links(text)
         if len(text_and_links) != 1 or text_and_links[0] != text:
 
             def _unicode(x):

--- a/src/nti/contentfragments/html.py
+++ b/src/nti/contentfragments/html.py
@@ -196,6 +196,9 @@ class _SanitizerFilter(sanitizer.Filter):
                     yield token
 
     def _find_links_in_text(self, token):
+        if self.link_finder is None:
+            yield token
+            
         text = token['data']
         text_and_links = self.link_finder.find_links(text) if self.link_finder else ()
         if len(text_and_links) != 1 or text_and_links[0] != text:

--- a/src/nti/contentfragments/html.py
+++ b/src/nti/contentfragments/html.py
@@ -123,7 +123,7 @@ class _NoopHyperlinkFormatter(object):
 
     def format(self, html_fragment):
         # TODO should this just return html_fragment?
-        raise NotImplemented
+        raise NotImplemented # pragma: no cover
 
 
 # But we define our own sanitizer mixin subclass and filter to be able to


### PR DESCRIPTION
The old implementation resulted in character data being dropped when no IHyperlinkFormatter was found in the registry. This resulted in the added test producing a value of `<html><body><p></p></body></html>` rather than the expected value `<html><body><p>look at this</p></body></html>`