### PR TITLE
Use a heuristic to detect when to run html2text on raw input strings.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,12 @@
 1.8.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix adapting base string input to plain text to behave more like 1.7
+  by only running the HTML to plain text algorithm if the input looks
+  like it may contain HTML markup. Note that in some instances where
+  characters like '<' were previously escaped to '&lt;', this will no
+  longer happen if the rest of the string doesn't look like HTML. See `issue 44
+  <https://github.com/NextThought/nti.contentfragments/issues/44>`_.
 
 
 1.8.0 (2021-10-06)

--- a/src/nti/contentfragments/tests/test_html.py
+++ b/src/nti/contentfragments/tests/test_html.py
@@ -149,6 +149,40 @@ Some ending text.
         expt = u'Hi, Ken.  Here is the answer.  Check this website www_xyz_com\n'
         self._check_sanitized(html, expt)
 
+    def test_markdown_like_input(self):
+        # In 1.8, this improperly resulted in "2\\. Lesson 2"
+        # See https://github.com/NextThought/nti.contentfragments/issues/44
+        html = u'2. Lesson 2'
+        expt = html
+        self._check_sanitized(html, expt)
+
+        # What if it's across multiple lines?
+        # Note that we strip each line.
+        html = u'2. \n Lesson 2'
+        expt = u'2.\n Lesson 2'
+        self._check_sanitized(html, expt)
+
+    def test_doesnt_escape_HTML_chars(self):
+        # In 1.7.0, this produced '2 + 2 &lt; 5 &gt; 2 - 1?'
+        # In 1.8.0, this produced '<html><body>2 + 2 &lt; 5 &gt; 2 - 1? </body></html>'
+        # Now, we want to be consistent and not escape those characters
+        html = u'2 + 2 < 5 > 2 - 1? '
+        expt = html
+        self._check_sanitized(html, expt)
+
+    def test_tags_across_multiple_lines(self):
+        html_no_end_trailing_spaces = u'<div \nclass="cls"\n >Some body'
+        # Like no_end_trailing_spaces without the trailing spaces
+        html_no_end = u'<div\nclass="cls"\n>Some body'
+        expt = "Some body"
+
+        for html in html_no_end_trailing_spaces, html_no_end:
+            self._check_sanitized(html, expt)
+
+            html_with_end = html + u'</div>'
+            self._check_sanitized(html_with_end, expt)
+
+
 class TestByteInputToPlainTextOutput(TestStringInputToPlainTextOutput):
 
     def _check_sanitized(self, html, expt): # pylint:disable=arguments-differ

--- a/src/nti/contentfragments/tests/test_html.py
+++ b/src/nti/contentfragments/tests/test_html.py
@@ -55,8 +55,8 @@ class _StringConversionMixin(object):
         inp = self.INP_FACTORY(inp)
         converted = self.CONV_IFACE(inp)
         __traceback_info__ = inp, type(inp), converted, type(converted)
-        assert_that(converted, is_(expect.strip()))
         assert_that(converted, verifiably_provides(self.EXP_IFACE))
+        assert_that(converted, is_(expect.strip()))
         return converted
 
     def _to_one_stripped_line(self, inp):
@@ -182,6 +182,17 @@ Some ending text.
             html_with_end = html + u'</div>'
             self._check_sanitized(html_with_end, expt)
 
+    def test_unclosed_attribute(self):
+        # Note that the attribute string is unclosed.
+        # In 1.7, this resulted in '', the empty string.
+        # In 1.8, we actually produce a ISanitizedHTMLContentFragment
+        html = u'<div><a onclick="window.location=\'http://google.com\'">Hi there!</a></div>'
+        expt = u'<html><body><a>Hi there!</a></body></html>'
+        self.EXP_IFACE = frg_interfaces.ISanitizedHTMLContentFragment
+        try:
+            self._check_sanitized(html, expt)
+        finally:
+            del self.EXP_IFACE
 
 class TestByteInputToPlainTextOutput(TestStringInputToPlainTextOutput):
 
@@ -189,6 +200,7 @@ class TestByteInputToPlainTextOutput(TestStringInputToPlainTextOutput):
         assert isinstance(html, type(u''))
         html = html.encode('latin-1')
         return super(TestByteInputToPlainTextOutput, self)._check_sanitized(html, expt)
+
 
 class TestStringToSanitizedHTML(_StringConversionMixin, ContentfragmentsLayerTest):
 


### PR DESCRIPTION
This fixes #44, but is only a partial fix to the entire issue, which is about context-sensitive conversions of output.