### PR TITLE
Add schema fields VerbatimPlainText and VerbatimPlainTextLine 

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,13 @@
+[MASTER]
+extension-pkg-whitelist=gevent.greenlet,gevent.libuv._corecffi,gevent.libev._corecffi,gevent.libev._corecffi.lib,gevent.local,gevent._ident
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions. But it can also result in false positives.
+# gevent: The changes for Python 3.7 in _ssl3.py lead to infinite recursion
+# in pylint 2.3.1/astroid 2.2.5 in that file unless we this this to 1
+# from the default of 100.
+#limit-inference-results=1
 
 [MESSAGES CONTROL]
 
@@ -28,9 +38,19 @@
 #   see https://github.com/PyCQA/pylint/issues/846
 # useless-suppression: the only way to avoid repeating it for specific statements everywhere that we
 #   do Py2/Py3 stuff is to put it here. Sadly this means that we might get better but not realize it.
-disable=wrong-import-position,
-    wrong-import-order,
-    missing-docstring,
+# In pylint 1.8.0, inconsistent-return-statements are created for the wrong reasons.
+# This code raises it, even though there's only one return (the implicit 'return None' is presumably
+# what triggers it):
+#  def foo():
+#    if baz:
+#      return 1
+# In Pylint 2dev1, needed for Python 3.7, we get spurious 'useless return' errors:
+# @property
+# def foo(self):
+#   return None # generates useless-return
+# Pylint 2.4 adds import-outside-toplevel. But we do that a lot to defer imports because of patching.
+# Pylint 2.6+ adds some python-3-only things that don't apply: raise-missing-from, super-with-arguments, consider-using-f-string, redundant-u-string-prefix
+disable=missing-docstring,
     ungrouped-imports,
     invalid-name,
     protected-access,
@@ -44,15 +64,19 @@ disable=wrong-import-position,
     too-many-arguments,
     redefined-builtin,
     useless-suppression,
-    mixed-indentation,
-    useless-object-inheritance
-
-#	undefined-all-variable
-
+    inconsistent-return-statements,
+    useless-return,
+    useless-object-inheritance,
+    import-outside-toplevel,
+    raise-missing-from,
+    super-with-arguments,
+    consider-using-f-string,
+    redundant-u-string-prefix
 
 [FORMAT]
 # duplicated from setup.cfg
 max-line-length=160
+max-module-lines=1100
 
 [MISCELLANEOUS]
 # List of note tags to take in consideration, separated by a comma.
@@ -73,24 +97,28 @@ dummy-variables-rgx=_.*
 generated-members=exc_clear
 
 # List of classes names for which member attributes should not be checked
-# (useful for classes with attributes dynamically set). This supports can work
+# (useful for classes with attributes dynamically set). This can work
 # with qualified names.
-# greenlet, Greenlet, parent, dead: all attempts to fix issues in greenlet.py
-# only seen on the service, e.g., self.parent.loop: class parent has no loop
-ignored-classes=SSLContext, SSLSocket, greenlet, Greenlet, parent, dead
+#ignored-classes=SSLContext, SSLSocket, greenlet, Greenlet, parent, dead
+
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=gevent._corecffi
+ignored-modules=gevent._corecffi,gevent.os,os,threading,gevent.libev.corecffi,gevent.socket,gevent.core,gevent.testing.support
 
 [DESIGN]
 max-attributes=12
+max-parents=10
 
 [BASIC]
 bad-functions=input
 # Prospector turns ot unsafe-load-any-extension by default, but
 # pylint leaves it off. This is the proximal cause of the
 # undefined-all-variable crash.
-#unsafe-load-any-extension = no
+unsafe-load-any-extension = yes
+
+# Local Variables:
+# mode: conf
+# End:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-1.8.1 (unreleased)
+1.9.0 (unreleased)
 ==================
 
 - Fix adapting base string input to plain text to behave more like 1.7
@@ -11,7 +11,10 @@
   characters like '<' were previously escaped to '&lt;', this will no
   longer happen if the rest of the string doesn't look like HTML. See `issue 44
   <https://github.com/NextThought/nti.contentfragments/issues/44>`_.
-
+- Add schema fields ``VerbatimPlainText`` and
+  ``VerbatimPlainTextLine`` to assume any incoming unicode value
+  already represents a plain text content fragment, instead of
+  (possibly) passing it through the HTML to plain text algorithm.
 
 1.8.0 (2021-10-06)
 ==================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -356,6 +356,7 @@ intersphinx_mapping = {
     'https://zopeinterface.readthedocs.io/en/latest/': None,
     'https://zopecomponent.readthedocs.io/en/latest/': None,
     'https://zopesite.readthedocs.io/en/latest/': None,
+    'https://zopeschema.readthedocs.io/en/latest/': None,
 }
 
 extlinks = {'issue': ('https://github.com/NextThought/nti.contentfragments/issues/%s',
@@ -363,5 +364,15 @@ extlinks = {'issue': ('https://github.com/NextThought/nti.contentfragments/issue
             'pr': ('https://github.com/NextThought/nti.contentfragments/pull/%s',
                    'pull request #')}
 
-autodoc_default_flags = ['members', 'show-inheritance']
-autoclass_content = 'both'
+# Sphinx 1.8+ prefers this to `autodoc_default_flags`. It's documented that
+# either True or None mean the same thing as just setting the flag, but
+# only None works in 1.8 (True works in 2.0)
+autodoc_default_options = {
+    'members': None,
+    'show-inheritance': None,
+}
+autodoc_member_order = 'groupwise'
+# Normally we use "both" here to get
+# documentation from both __init__  and the class docstring,
+# but we inherit a bunch of weird stuff in __init__ for our schema fields.
+autoclass_content = 'class'

--- a/docs/nti.contentfragments.schema.rst
+++ b/docs/nti.contentfragments.schema.rst
@@ -3,5 +3,4 @@ nti.contentfragments.schema module
 
 .. automodule:: nti.contentfragments.schema
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def _read(fname):
     with codecs.open(fname, encoding='utf-8') as f:
         return f.read()
 
-version = '1.8.1.dev0'
+version = '1.9.0.dev0'
 
 setup(
     name='nti.contentfragments',

--- a/src/nti/contentfragments/schema.py
+++ b/src/nti/contentfragments/schema.py
@@ -3,8 +3,6 @@
 """
 Helper classes to use content fragments in :mod:`zope.interface`
 or :mod:`zope.schema` declarations.
-
-.. $Id: schema.py 85352 2016-03-26 19:08:54Z carlos.sanchez $
 """
 
 from __future__ import print_function, absolute_import, division
@@ -110,11 +108,20 @@ class _FromUnicodeMixin(object):
 @implementer(ITextUnicodeContentFragmentField)
 class TextUnicodeContentFragment(_FromUnicodeMixin, Object, Text):
     """
-    A :class:`zope.schema.Text` type that also requires the object implement
-    an interface descending from :class:`~.IUnicodeContentFragment`.
+    A :class:`zope.schema.Text` type that also requires the object
+    implement an interface descending from
+    :class:`~.IUnicodeContentFragment`.
 
-    Pass the keyword arguments for :class:`zope.schema.Text` to the constructor; the ``schema``
-    argument for :class:`~zope.schema.Object` is already handled.
+    Pass the keyword arguments for :class:`zope.schema.Text` to the
+    constructor; the ``schema`` argument for
+    :class:`~zope.schema.Object` is already handled.
+
+    .. caution::
+
+        This will perform conversions on the input data, stripping or adjusting
+        things that "look like" HTML, if it does not already implement the required interface;
+        the actual value is likely to be a :class:`~.ISanitizedHTMLContentFragment`
+        or a :class:`~.IPlainTextContentFragment`.
     """
 
     _iface = IUnicodeContentFragment
@@ -124,14 +131,25 @@ class TextUnicodeContentFragment(_FromUnicodeMixin, Object, Text):
 @implementer(ITextLineUnicodeContentFragmentField)
 class TextLineUnicodeContentFragment(_FromUnicodeMixin, Object, TextLine):
     """
-    A :class:`zope.schema.TextLine` type that also requires the object implement
-    an interface descending from :class:`~.IUnicodeContentFragment`.
+    A :class:`zope.schema.TextLine` type that also requires the object
+    implement an interface descending from
+    :class:`~.IUnicodeContentFragment`.
 
-    Pass the keyword arguments for :class:`zope.schema.TextLine` to the constructor; the ``schema``
-    argument for :class:`~zope.schema.Object` is already handled.
+    Pass the keyword arguments for :class:`zope.schema.TextLine` to
+    the constructor; the ``schema`` argument for
+    :class:`~zope.schema.Object` is already handled.
 
-    If you pass neither a `default` nor `defaultFactory` argument, a `defaultFactory`
-    argument will be provided to construct an empty content fragment.
+    If you pass neither a *default* nor *defaultFactory* argument, a
+    *defaultFactory* argument will be provided to construct an empty
+    content fragment.
+
+    .. caution::
+
+        This will perform conversions on the input data, stripping or adjusting
+        things that "look like" HTML, if it does not already implement the required interface;
+        the actual value is
+        likely to be a :class:`~.ISanitizedHTMLContentFragment`
+        or a :class:`~.IPlainTextContentFragment`.
     """
 
     _iface = IUnicodeContentFragment
@@ -141,12 +159,17 @@ class TextLineUnicodeContentFragment(_FromUnicodeMixin, Object, TextLine):
 @implementer(ILatexFragmentTextLineField)
 class LatexFragmentTextLine(TextLineUnicodeContentFragment):
     """
-    A :class:`~zope.schema.TextLine` that requires content to be in LaTeX format.
+    A :class:`~zope.schema.TextLine` that requires content to be in
+    LaTeX format.
 
-    Pass the keyword arguments for :class:`~zope.schema.TextLine` to the constructor; the ``schema``
-    argument for :class:`~zope.schema.Object` is already handled.
+    Pass the keyword arguments for :class:`~zope.schema.TextLine` to
+    the constructor; the ``schema`` argument for
+    :class:`~zope.schema.Object` is already handled.
 
-    .. note:: If you provide a ``default`` string that does not already provide :class:`.ILatexContentFragment`,
+    .. note::
+
+        If you provide a *default* string that does not
+        already provide :class:`.ILatexContentFragment`,
         one will be created simply by copying; no validation or transformation will occur.
     """
 
@@ -157,13 +180,23 @@ class LatexFragmentTextLine(TextLineUnicodeContentFragment):
 @implementer(IPlainTextLineField)
 class PlainTextLine(TextLineUnicodeContentFragment):
     """
-    A :class:`~zope.schema.TextLine` that requires content to be plain text.
+    A :class:`~zope.schema.TextLine` that requires content to be plain
+    text.
 
-    Pass the keyword arguments for :class:`~zope.schema.TextLine` to the constructor; the ``schema``
-    argument for :class:`~zope.schema.Object` is already handled.
+    Pass the keyword arguments for :class:`~zope.schema.TextLine` to
+    the constructor; the ``schema`` argument for
+    :class:`~zope.schema.Object` is already handled.
 
-    .. note:: If you provide a ``default`` string that does not already provide :class:`.ILatexContentFragment`,
+    .. note::
+
+        If you provide a *default* string that does
+        not already provide :class:`.ILatexContentFragment`,
         one will be created simply by copying; no validation or transformation will occur.
+
+    .. caution::
+
+        This will perform conversions on the input data, stripping
+        things that "look like" HTML, if it does not already implement the required interface.
     """
 
     _iface = IPlainTextContentFragment
@@ -173,13 +206,17 @@ class PlainTextLine(TextLineUnicodeContentFragment):
 @implementer(IHTMLContentFragmentField)
 class HTMLContentFragment(TextUnicodeContentFragment):
     """
-    A :class:`~zope.schema.Text` type that also requires the object implement
-    an interface descending from :class:`.IHTMLContentFragment`.
+    A :class:`~zope.schema.Text` type that also requires the object
+    implement an interface descending from
+    :class:`.IHTMLContentFragment`.
 
-    Pass the keyword arguments for :class:`zope.schema.Text` to the constructor; the ``schema``
-    argument for :class:`~zope.schema.Object` is already handled.
+    Pass the keyword arguments for :class:`zope.schema.Text` to the
+    constructor; the ``schema`` argument for
+    :class:`~zope.schema.Object` is already handled.
 
-    .. note:: If you provide a ``default`` string that does not already provide :class:`.IHTMLContentFragment`,
+    .. note::
+
+        If you provide a *default* string that does not already provide :class:`.IHTMLContentFragment`,
         one will be created simply by copying; no validation or transformation will occur.
     """
 
@@ -190,17 +227,20 @@ class HTMLContentFragment(TextUnicodeContentFragment):
 @implementer(ISanitizedHTMLContentFragmentField)
 class SanitizedHTMLContentFragment(HTMLContentFragment):
     """
-    A :class:`Text` type that also requires the object implement
-    an interface descending from :class:`.ISanitizedHTMLContentFragment`.
+    A :class:`Text` type that also requires the object implement an
+    interface descending from :class:`.ISanitizedHTMLContentFragment`.
     Note that the default adapter for this can actually produce
-    ``IPlainTextContentFragment`` if there is no HTML present in the input.
+    ``IPlainTextContentFragment`` if there is no HTML present in the
+    input.
 
-    Pass the keyword arguments for :class:`zope.schema.Text` to the constructor; the ``schema``
-    argument for :class:`~zope.schema.Object` is already handled.
+    Pass the keyword arguments for :class:`zope.schema.Text` to the
+    constructor; the ``schema`` argument for
+    :class:`~zope.schema.Object` is already handled.
 
-    .. note:: If you provide a ``default`` string that does not already provide :class:`.ISanitizedHTMLContentFragment`,
+    .. note::
+
+        If you provide a ``default`` string that does not already provide :class:`.ISanitizedHTMLContentFragment`,
         one will be created simply by copying; no validation or transformation will occur.
-
     """
 
     _iface = ISanitizedHTMLContentFragment
@@ -210,17 +250,19 @@ class SanitizedHTMLContentFragment(HTMLContentFragment):
 @implementer(IRstContentFragmentField)
 class RstContentFragment(TextUnicodeContentFragment):
     """
-    A :class:`Text` type that also requires the object implement
-    an interface descending from :class:`.IRstContentFragment`.
-    Note that currently this does no validation of the content to
-    ensure it is valid reStructuredText.
+    A :class:`zope.schema.Text` type that also requires the object implement an
+    interface descending from :class:`~.IRstContentFragment`. Note that
+    currently this does no validation of the content to ensure it is
+    valid reStructuredText.
 
-    Pass the keyword arguments for :class:`zope.schema.Text` to the constructor; the ``schema``
-    argument for :class:`~zope.schema.Object` is already handled.
+    Pass the keyword arguments for :class:`zope.schema.Text` to the
+    constructor; the ``schema`` argument for
+    :class:`~zope.schema.Object` is already handled.
 
-    .. note:: If you provide a ``default`` string that does not already provide :class:`.IRstContentFragment`,
+    .. note::
+
+        If you provide a *default* string that does not already provide :class:`.IRstContentFragment`,
         one will be created simply by copying; no validation or transformation will occur.
-
     """
 
     _iface = IRstContentFragment
@@ -237,13 +279,22 @@ class RstContentFragment(TextUnicodeContentFragment):
 @implementer(IPlainTextField)
 class PlainText(TextUnicodeContentFragment):
     """
-    A :class:`zope.schema.Text` that requires content to be plain text.
+    A :class:`zope.schema.Text` that requires content to be plain
+    text.
 
-    Pass the keyword arguments for :class:`~zope.schema.Text` to the constructor; the ``schema``
-    argument for :class:`~zope.schema.Object` is already handled.
+    Pass the keyword arguments for :class:`~zope.schema.Text` to the
+    constructor; the ``schema`` argument for
+    :class:`~zope.schema.Object` is already handled.
 
-    .. note:: If you provide a ``default`` string that does not already provide :class:`.IPlainTextContentFragment`,
+    .. note::
+
+        If you provide a *default* string that does not already provide :class:`.IPlainTextContentFragment`,
         one will be created simply by copying; no validation or transformation will occur.
+
+    .. caution::
+
+        This will perform conversions on the input data, stripping
+        things that "look like" HTML, if it does not already implement the required interface.
     """
 
     _iface = IPlainTextContentFragment
@@ -259,7 +310,7 @@ class Tag(PlainTextLine):
     def fromUnicode(self, value):
         return super(Tag, self).fromUnicode(value.lower())
 
-    def constraint(self, value):
+    def constraint(self, value): # pylint:disable=method-hidden
         return super(Tag, self).constraint(value) and ' ' not in value
 
 def Title():

--- a/src/nti/contentfragments/tests/__init__.py
+++ b/src/nti/contentfragments/tests/__init__.py
@@ -4,7 +4,8 @@
 from __future__ import print_function, absolute_import
 __docformat__ = "restructuredtext en"
 
-# pylint:disable=useless-object-inheritance
+
+import unittest
 
 from hamcrest import assert_that
 from hamcrest import is_
@@ -36,7 +37,7 @@ class ContentfragmentsTestLayer(ZopeComponentLayer, ConfiguringLayerMixin):
     def testTearDown(cls):
         pass
 
-import unittest
+
 
 class ContentfragmentsLayerTest(unittest.TestCase):
     layer = ContentfragmentsTestLayer


### PR DESCRIPTION
These assume any incoming unicode value already represents a plain text content fragment, instead of (possibly) passing it through the HTML to plain text algorithm.

CAUTION: depending on your use case, this may or may not be safe.